### PR TITLE
Improve glorp interoperability

### DIFF
--- a/BaselineOfMySQL/BaselineOfMySQL.class.st
+++ b/BaselineOfMySQL/BaselineOfMySQL.class.st
@@ -16,18 +16,25 @@ BaselineOfMySQL >> baseline: spec [
 		do: [ 
 			spec blessing: #baseline.
 								
+			"Dependencies"			
+			spec 
+				baseline: 'NeoJSON' with: [ spec repository: 'github://svenvc/NeoJSON:master/repository' ];
+				baseline: 'ZTimestamp' with: [ spec repository: 'github://svenvc/ztimestamp:master/repository' ];
+				baseline: 'Glorp' with: [ spec repository: 'github://pharo-rdbms/glorp:master/'].
 			"Packages"
 			spec 
-				package: 'MySQL-Core';
+				package: 'MySQL-Core' with: [ spec requires: #('NeoJSON' 'ZTimestamp') ];
+				package: 'MySQL-Glorp' with: [ spec requires: #('MySQL-Core' 'Glorp') ];
 				package: 'MySQL-Core-Tests' with: [ spec requires: #('MySQL-Core') ];
 				package: 'MySQL-Core-Tests-Integration' with: [ spec requires: #('MySQL-Core-Tests') ].				
 						
 			"Groups"
 			spec
-				group: 'Core' with: #('MySQL-Core');		
-				group: 'Tests' with: #('MySQL-Core-Tests' 'MySQL-Core-Tests-Integration'); 				
-				group: 'all' with: #('Core' 'Tests');
-				group: 'default' with: #('all')].
+				group: 'default' with: #('all');
+				group: 'core' with: #('MySQL-Core');		
+				group: 'glorp' with: #('MySQL-Glorp');				
+				group: 'all' with: #('MySQL-Core' 'MySQL-Core-Tests' 'MySQL-Core-Tests-Integration')
+				].
 ]
 
 { #category : #accessing }

--- a/MySQL-Core/MySQLBinaryRowData.class.st
+++ b/MySQL-Core/MySQLBinaryRowData.class.st
@@ -38,6 +38,11 @@ MySQLBinaryRowData >> isColumnNullAt: index [
 ]
 
 { #category : #accessing }
+MySQLBinaryRowData >> last [
+	^ self atIndex: (columnValues size)
+]
+
+{ #category : #accessing }
 MySQLBinaryRowData >> nullBitMap: byteArray [ "primarily for testing"
 	nullBitMap := byteArray 
 	

--- a/MySQL-Core/MySQLCommandQuery.class.st
+++ b/MySQL-Core/MySQLCommandQuery.class.st
@@ -68,6 +68,16 @@ MySQLCommandQuery >> readOneRow: fieldCount [
 ]
 
 { #category : #reading }
+MySQLCommandQuery >> readOneRow: fieldCount fields: fields [
+	| row |
+	row := MySQLQueryRowData new fields: fields; yourself.
+	row columnCount: fieldCount.
+	row read: session read.
+	^ row
+	
+]
+
+{ #category : #reading }
 MySQLCommandQuery >> readResponse [
 	| resp |
 	resp := self readResult.
@@ -84,7 +94,7 @@ MySQLCommandQuery >> readResult [
 		ifFalse: [ resultSetHdr := self readRsHeader ].
 	fields := self readFields.
 	fieldsEof := self readEof.
-	rows := self readRowData: resultSetHdr fieldCount.
+	rows := self readRowData: resultSetHdr fieldCount fields: fields.
 	rowsEof := self readEof.
 	^ MySQLResultSet new
 		header: resultSetHdr;
@@ -103,6 +113,19 @@ MySQLCommandQuery >> readRowData: fieldCount [
 	[self gotEof] whileFalse: [ 
 		"Read each field and save it"
 		row := self readOneRow: fieldCount.
+		respRows add: row].
+		
+	^ respRows asArray
+	
+]
+
+{ #category : #reading }
+MySQLCommandQuery >> readRowData: fieldCount fields: fields [
+	| respRows row |
+	respRows := OrderedCollection new.
+	[self gotEof] whileFalse: [ 
+		"Read each field and save it"
+		row := self readOneRow: fieldCount fields: fields.
 		respRows add: row].
 		
 	^ respRows asArray

--- a/MySQL-Core/MysqlField.class.st
+++ b/MySQL-Core/MysqlField.class.st
@@ -28,7 +28,6 @@ Class {
 		'PrimaryKeyFlag',
 		'SetFlag',
 		'TimestampFlag',
-		'TypeConverters',
 		'UniqueKeyFlag',
 		'UnsignedFlag',
 		'ZeroFillFlag'
@@ -58,17 +57,7 @@ MySQLField class >> initBitMasksForFlags [
 { #category : #initialization }
 MySQLField class >> initialize [
 	"self initialize"
-	self initBitMasksForFlags.
-	self initializeTypeConverters.
-]
-
-{ #category : #initialization }
-MySQLField class >> initializeTypeConverters [
-	TypeConverters ifNil: [ 
-		TypeConverters := Dictionary new. 
-		
-		
-		]
+	self initBitMasksForFlags
 ]
 
 { #category : #accessing }
@@ -149,12 +138,4 @@ MySQLField >> table [
 MySQLField >> type [
 	^ type
 	
-]
-
-{ #category : #'as yet unclassified' }
-MySQLField >> typedValueFrom: aString [
-	^(TypeConverters 
-		at: self type 
-		ifAbsent: [ self error: ('No Type Converter Registered For Type: ', (self type asString)) ])
-			value: aString
 ]

--- a/MySQL-Core/MysqlField.class.st
+++ b/MySQL-Core/MysqlField.class.st
@@ -28,6 +28,7 @@ Class {
 		'PrimaryKeyFlag',
 		'SetFlag',
 		'TimestampFlag',
+		'TypeConverters',
 		'UniqueKeyFlag',
 		'UnsignedFlag',
 		'ZeroFillFlag'
@@ -58,7 +59,16 @@ MySQLField class >> initBitMasksForFlags [
 MySQLField class >> initialize [
 	"self initialize"
 	self initBitMasksForFlags.
-	
+	self initializeTypeConverters.
+]
+
+{ #category : #initialization }
+MySQLField class >> initializeTypeConverters [
+	TypeConverters ifNil: [ 
+		TypeConverters := Dictionary new. 
+		
+		
+		]
 ]
 
 { #category : #accessing }
@@ -139,4 +149,12 @@ MySQLField >> table [
 MySQLField >> type [
 	^ type
 	
+]
+
+{ #category : #'as yet unclassified' }
+MySQLField >> typedValueFrom: aString [
+	^(TypeConverters 
+		at: self type 
+		ifAbsent: [ self error: ('No Type Converter Registered For Type: ', (self type asString)) ])
+			value: aString
 ]

--- a/MySQL-Core/MysqlHelper.class.st
+++ b/MySQL-Core/MysqlHelper.class.st
@@ -65,7 +65,7 @@ MySQLHelper class >> decodeLcsFrom: aStream [
 	"parses length coded string"
 	| len |
 	len := self decodeLcbFrom: aStream.
-	len = -1 ifTrue: [^ 'NULL'].
+	len = -1 ifTrue: [^ nil].
 	^ aStream next: len.
 	
 ]

--- a/MySQL-Core/MysqlQueryRowData.class.st
+++ b/MySQL-Core/MysqlQueryRowData.class.st
@@ -37,6 +37,11 @@ MySQLQueryRowData >> fields: anObject [
 	fields := anObject
 ]
 
+{ #category : #accessing }
+MySQLQueryRowData >> last [
+	^ columns atIndex: (columns size) 
+]
+
 { #category : #parsing }
 MySQLQueryRowData >> parse [
 	| indx value field |

--- a/MySQL-Core/MysqlQueryRowData.class.st
+++ b/MySQL-Core/MysqlQueryRowData.class.st
@@ -5,7 +5,8 @@ Class {
 	#name : #MySQLQueryRowData,
 	#superclass : #MySQLRowData,
 	#instVars : [
-		'columns'
+		'columns',
+		'fields'
 	],
 	#category : #'MySQL-Core-Packet-RowData'
 }
@@ -26,14 +27,73 @@ MySQLQueryRowData >> columnCount: aCount [
 	
 ]
 
+{ #category : #accessing }
+MySQLQueryRowData >> fields [
+	^ fields
+]
+
+{ #category : #accessing }
+MySQLQueryRowData >> fields: anObject [
+	fields := anObject
+]
+
 { #category : #parsing }
 MySQLQueryRowData >> parse [
-	|indx value |
+	| indx value field |
 
 	indx := 1.
 	[inStream atEnd] whileFalse: [
-		value := (self decodeLcsFrom: inStream) asString.
+		field := fields at: indx.
+		value := (self readColumnFrom: inStream perDescrption: field).
 		columns at: indx put: value.
 		indx := indx + 1].
+	
+]
+
+{ #category : #parsing }
+MySQLQueryRowData >> readColumnFrom: aStream perDescrption: columnDescr [
+	| string |
+	string := (self decodeLcsFrom: aStream) ifNotNil: [:s | s asString] ifNil: [^nil].
+	^columnDescr type 
+		caseOf: {
+		[MySQLTypes typeTINY]->[string asInteger].
+		[MySQLTypes typeSHORT]->[string asInteger].
+		[MySQLTypes typeINT24]->[string asInteger].	
+		[MySQLTypes typeLONG]->[string asInteger].	
+		[MySQLTypes typeLONGLONG]->[string asInteger].
+
+		[MySQLTypes typeFLOAT]->[string asNumber].
+		[MySQLTypes typeDOUBLE]->[string asNumber].
+		[MySQLTypes typeDECIMAL]->[ScaledDecimal readFrom: string].
+		[MySQLTypes typeNEWDECIMAL]->[ScaledDecimal readFrom: string].
+	
+		[MySQLTypes typeSTRING]->[string].
+		[MySQLTypes typeVARCHAR]->[string].
+		[MySQLTypes typeVARSTRING]->[string].
+	
+		[MySQLTypes typeTIME]->[Time fromString: string].
+		[MySQLTypes typeDATE]->[Date fromString: string].
+		[MySQLTypes typeDATETIME]->[DateAndTime fromString: string].
+		[MySQLTypes typeTIMESTAMP]->[DateAndTime fromString: string].
+		[MySQLTypes typeYEAR]->[string asInteger].
+		[MySQLTypes typeNEWDATE]->[DateAndTime fromString: string].
+	
+		[MySQLTypes typeTINYBLOB]->[string].
+		[MySQLTypes typeBLOB]->[string].
+		[MySQLTypes typeMEDIUMBLOB]->[string].
+		[MySQLTypes typeLONGBLOB]->[string].
+	
+		[MySQLTypes typeJSON]->[NeoJSONReader fromString: string].
+		
+		[MySQLTypes typeNULL]->[self shouldBeImplemented].
+	
+		[MySQLTypes typeGEOMETRY]->[self shouldBeImplemented].
+		[MySQLTypes typeSET]->[self shouldBeImplemented].
+		[MySQLTypes typeENUM]->[self shouldBeImplemented].
+		[MySQLTypes typeBIT]->[string asInteger].
+		} 
+		otherwise: [^ self error: 'Unknown mysql type'].
+		
+	
 	
 ]

--- a/MySQL-Core/MysqlRowData.class.st
+++ b/MySQL-Core/MysqlRowData.class.st
@@ -19,8 +19,63 @@ MySQLRowData >> atIndex: indx [
 	
 ]
 
+{ #category : #accessing }
+MySQLRowData >> eighth [  
+	^self atIndex: 8
+]
+
+{ #category : #accessing }
+MySQLRowData >> fifth [ 
+	^self atIndex: 5
+]
+
+{ #category : #accessing }
+MySQLRowData >> first [ 
+	^self atIndex: 1
+]
+
+{ #category : #accessing }
+MySQLRowData >> fourth [ 
+	^self atIndex: 4
+]
+
+{ #category : #accessing }
+MySQLRowData >> last [  
+	self subclassResponsibility 
+]
+
+{ #category : #accessing }
+MySQLRowData >> ninth [  
+	^self atIndex: 9
+]
+
 { #category : #parsing }
 MySQLRowData >> parse [
 	self subclassResponsibility 
 	
+]
+
+{ #category : #accessing }
+MySQLRowData >> second [ 
+	^self atIndex: 2
+]
+
+{ #category : #accessing }
+MySQLRowData >> seventh [ 
+	^self atIndex: 7
+]
+
+{ #category : #accessing }
+MySQLRowData >> sixth [ 
+	^self atIndex: 6
+]
+
+{ #category : #accessing }
+MySQLRowData >> tenth [  
+	^self atIndex: 10
+]
+
+{ #category : #accessing }
+MySQLRowData >> third [ 
+	^self atIndex: 3
 ]

--- a/MySQL-Core/MysqlStringRowData.class.st
+++ b/MySQL-Core/MysqlStringRowData.class.st
@@ -16,6 +16,12 @@ MySQLStringRowData >> atIndex: indx [
 	
 ]
 
+{ #category : #accessing }
+MySQLStringRowData >> last [
+	^ self atIndex: (columnStrings size)
+	
+]
+
 { #category : #parsing }
 MySQLStringRowData >> parse [
 	super parse.

--- a/MySQL-Core/MysqlTypes.class.st
+++ b/MySQL-Core/MysqlTypes.class.st
@@ -15,6 +15,7 @@ Class {
 		'TypeFLOAT',
 		'TypeGEOMETRY',
 		'TypeINT24',
+		'TypeJSON',
 		'TypeLONG',
 		'TypeLONGBLOB',
 		'TypeLONGLONG',
@@ -75,6 +76,7 @@ MySQLTypes class >> initFieldTypes [
  	TypeFLOAT := 4.
  	TypeGEOMETRY := 255.
  	TypeINT24 := 9.
+	TypeJSON := 245.
  	TypeLONG := 3.
  	TypeLONGLONG := 8.
  	TypeLONGBLOB := 251.
@@ -97,6 +99,7 @@ MySQLTypes class >> initFieldTypes [
 
 { #category : #'class initialization' }
 MySQLTypes class >> initialize [
+	"MySQLTypes initialize"
 	self initFieldTypes
 
 ]
@@ -215,6 +218,12 @@ MySQLTypes class >> typeGEOMETRY [
 { #category : #'accessing - types' }
 MySQLTypes class >> typeINT24 [
 	^ TypeINT24
+	
+]
+
+{ #category : #'accessing - types' }
+MySQLTypes class >> typeJSON [
+	^ TypeJSON
 	
 ]
 


### PR DESCRIPTION
Changed MySQLQueryRowData to convert strings to Smalltalk types on fetch.

Updated the queries to fetch schema information, fixing a bug that misidentified columns as primary key when they were actually foreign keys.

Also added support for JSON data type.

Needs more tests.