### PR TITLE
Support binding decimals with scale >= 10 to parameters

### DIFF
--- a/MySQL-Core-Tests/MySQLBindParameterDecimalTest.class.st
+++ b/MySQL-Core-Tests/MySQLBindParameterDecimalTest.class.st
@@ -1,0 +1,49 @@
+Class {
+	#name : #MySQLBindParameterDecimalTest,
+	#superclass : #TestCase,
+	#instVars : [
+		'theParam'
+	],
+	#category : #'MySQL-Core-Tests-Utilities'
+}
+
+{ #category : #running }
+MySQLBindParameterDecimalTest >> setUp [
+	super setUp.
+	theParam := MySQLBindParameter new.
+	
+]
+
+{ #category : #accessing }
+MySQLBindParameterDecimalTest >> storeBinary [
+	ByteArray streamContents: [:strm | 
+		theParam storeBinaryOn: strm.
+		^ strm contents]	
+	
+]
+
+{ #category : #tests }
+MySQLBindParameterDecimalTest >> testParamDecimal [
+	theParam bindValue: 12.00s2.
+	self assert: theParam detectParamType equals: MySQLTypes typeDECIMAL
+]
+
+{ #category : #tests }
+MySQLBindParameterDecimalTest >> testStoreBinaryLargeScale [
+	theParam bindValue: 1.0s10.
+	self
+		assert: self storeBinary
+		equals: #[12] , '1.0000000000' asByteArray.
+	theParam bindValue: 1.23456789012s.
+	self
+		assert: self storeBinary
+		equals: #[13] , '1.23456789012' asByteArray
+]
+
+{ #category : #tests }
+MySQLBindParameterDecimalTest >> testStoreBinarySmallScale [
+	theParam bindValue: 12.345s.
+	self assert: self storeBinary equals: #[6] , '12.345' asByteArray.
+	theParam bindValue: 1.23s.
+	self assert: self storeBinary equals: #[4] , '1.23' asByteArray
+]

--- a/MySQL-Core/MySQLBindParameter.class.st
+++ b/MySQL-Core/MySQLBindParameter.class.st
@@ -99,9 +99,12 @@ MySQLBindParameter >> dateTimeBytes [
 { #category : #writes }
 MySQLBindParameter >> decimalBytes [
 	"For scaled decimal"
-	ByteArray streamContents: [:strm |
-		MySQLHelper encodeLcs: (paramValue printString allButLast:2) asByteArray on: strm.
-		^ strm contents]
+
+	^ ByteArray
+		streamContents: [ :strm | 
+			MySQLHelper
+				encodeLcs: (paramValue printShowingDecimalPlaces: paramValue scale) asByteArray
+				on: strm ]
 ]
 
 { #category : #accessing }

--- a/MySQL-Core/MySQLOkay.class.st
+++ b/MySQL-Core/MySQLOkay.class.st
@@ -27,17 +27,17 @@ MySQLOkay >> hasMoreResults [
 ]
 
 { #category : #accessing }
+MySQLOkay >> insertId [
+	^ insertId 
+]
+
+{ #category : #accessing }
 MySQLOkay >> inTransaction [
 	| autoCommit inTx |
 	autoCommit := (serverStatus bitAnd: MySQLServerStatus statusInTransaction) ~= 0.
 	inTx := (serverStatus bitAnd: MySQLServerStatus statusInTransaction) ~= 0.
 	^ autoCommit and: inTx
 	
-]
-
-{ #category : #accessing }
-MySQLOkay >> insertId [
-	^ insertId 
 ]
 
 { #category : #testing }


### PR DESCRIPTION
The existing implementation assumes exactly one digit of scale, so for scales >= 10 it will send a trailing `s` to MySQL, presumably leading to an error. Seems like the best approach to explicitly ask the ScaledDecimal to print just the digits part, that way we don't have to strip anything off. Plus a test that this works properly.